### PR TITLE
feat(edge): implement edge middleware geolocation routing and CDN caching headers

### DIFF
--- a/backend/src/controllers/plant.controller.js
+++ b/backend/src/controllers/plant.controller.js
@@ -208,6 +208,7 @@ async function mapPlants(req, res) {
 
     if (dbError) return error(res, dbError.message, 400);
 
+    res.set('Cache-Control', 'public, max-age=60, s-maxage=300, stale-while-revalidate=60');
     return success(res, data);
   } catch (err) {
     console.error('mapPlants error:', err);

--- a/backend/src/controllers/post.controller.js
+++ b/backend/src/controllers/post.controller.js
@@ -244,6 +244,7 @@ async function mapPlantations(req, res) {
 
     if (dbError) return error(res, dbError.message, 400);
 
+    res.set('Cache-Control', 'public, max-age=60, s-maxage=300, stale-while-revalidate=60');
     return success(res, data);
   } catch (err) {
     console.error('mapPlantations error:', err);

--- a/frontend/src/app/map/page.tsx
+++ b/frontend/src/app/map/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { useEffect, useState } from 'react';
-import { useRouter } from 'next/navigation';
+import { useEffect, useState, Suspense } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { useAuth } from '@/lib/auth';
 import { plantsApi, feedApi } from '@/services/api';
 import type { MapPlant, Post } from '@/types';
@@ -19,18 +19,25 @@ const LeafletMap = dynamic(() => import('@/components/map/LeafletMap'), {
   )
 });
 
-export default function MapPage() {
+function MapContent() {
   const { isAuthenticated, loading: authLoading } = useAuth();
   const router = useRouter();
+  const searchParams = useSearchParams();
+  
   const [plants, setPlants] = useState<MapPlant[]>([]);
   const [plantations, setPlantations] = useState<Post[]>([]);
   const [loading, setLoading] = useState(true);
+
+  // Parse edge geolocated coordinates from query string
+  const latParam = searchParams.get('lat');
+  const lngParam = searchParams.get('lng');
+  const centerLat = latParam ? parseFloat(latParam) : undefined;
+  const centerLng = lngParam ? parseFloat(lngParam) : undefined;
 
   useEffect(() => {
     if (!authLoading && !isAuthenticated) { router.push('/login'); return; }
     if (!isAuthenticated) return;
     
-    // No need to set loading here as it's true by default and handled in finally
     Promise.all([
       plantsApi.getMapPlants(),
       feedApi.getMapPlantations(),
@@ -77,7 +84,12 @@ export default function MapPage() {
         </div>
       </div>
 
-      <LeafletMap plants={plants} plantations={plantations} />
+      <LeafletMap 
+        plants={plants} 
+        plantations={plantations} 
+        centerLat={centerLat} 
+        centerLng={centerLng} 
+      />
 
       {/* Floating Legend */}
       <div className="absolute bottom-10 right-10 z-[1000] w-64 bg-white/90 backdrop-blur-md rounded-[2.5rem] border border-white shadow-2xl p-6">
@@ -114,5 +126,18 @@ function LegendItem({ color, label, count, icon }: { color: string, label: strin
       </div>
       <span className="text-[10px] font-black text-gray-300 group-hover:text-emerald-600 transition-colors bg-gray-50 px-2 py-1 rounded-full">{count}</span>
     </div>
+  );
+}
+
+export default function MapPage() {
+  return (
+    <Suspense fallback={
+      <div className="h-[calc(100vh-64px)] w-full flex flex-col items-center justify-center bg-gray-50 gap-4">
+        <div className="w-12 h-12 border-4 border-emerald-100 border-t-emerald-600 rounded-full animate-spin" />
+        <p className="text-gray-500 font-black tracking-widest uppercase text-xs">Synchronizing Eco-Data</p>
+      </div>
+    }>
+      <MapContent />
+    </Suspense>
   );
 }

--- a/frontend/src/components/map/LeafletMap.tsx
+++ b/frontend/src/components/map/LeafletMap.tsx
@@ -19,17 +19,30 @@ const parseLngLat = (location: string | null): [number, number] | null => {
 interface LeafletMapProps {
   plants: MapPlant[];
   plantations: Post[];
+  centerLat?: number;
+  centerLng?: number;
 }
 
 // ─── Map Controller ──────────────────────────────────────────
 
-const MapController = () => {
+interface MapControllerProps {
+  centerLat?: number;
+  centerLng?: number;
+}
+
+const MapController = ({ centerLat, centerLng }: MapControllerProps) => {
   const map = useMap();
   useEffect(() => {
     map.on('locationfound', (e: L.LocationEvent) => {
       map.flyTo(e.latlng, 14, { duration: 2 });
     });
   }, [map]);
+
+  useEffect(() => {
+    if (centerLat !== undefined && centerLng !== undefined) {
+      map.flyTo([centerLat, centerLng], 11, { duration: 1.5 });
+    }
+  }, [map, centerLat, centerLng]);
 
   return (
     <div className="absolute top-6 right-6 z-[1000] flex flex-col gap-2">
@@ -67,7 +80,7 @@ const MapController = () => {
 
 // ─── Component ───────────────────────────────────────────────
 
-export default function LeafletMap({ plants, plantations }: LeafletMapProps) {
+export default function LeafletMap({ plants, plantations, centerLat, centerLng }: LeafletMapProps) {
   const iconsRef = useRef<Record<string, L.DivIcon>>({});
 
   // Initialize icons
@@ -132,12 +145,12 @@ export default function LeafletMap({ plants, plantations }: LeafletMapProps) {
       `}</style>
       
       <MapContainer
-        center={[20.5937, 78.9629]}
-        zoom={5}
+        center={centerLat !== undefined && centerLng !== undefined ? [centerLat, centerLng] : [20.5937, 78.9629]}
+        zoom={centerLat !== undefined && centerLng !== undefined ? 11 : 5}
         style={{ width: '100%', height: '100%' }}
         scrollWheelZoom
       >
-        <MapController />
+        <MapController centerLat={centerLat} centerLng={centerLng} />
         <TileLayer
           attribution='&copy; OpenStreetMap'
           url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -1,0 +1,40 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+
+/**
+ * Next.js Edge Middleware
+ * Intercepts requests to the /map page, extracts Vercel Edge Geolocation metadata,
+ * and performs a transparent rewrite to append location query parameters.
+ */
+export function middleware(request: NextRequest) {
+  const { pathname, searchParams } = request.nextUrl;
+
+  // Intercept the map page to apply Edge Geolocation coordinates
+  if (pathname === '/map') {
+    // If the coordinates are already explicitly specified in the query parameters, skip rewrite
+    if (!searchParams.has('lat') || !searchParams.has('lng')) {
+      const geo = request.geo || {};
+      
+      // Default to New Delhi, India coordinates during local dev or if geo is unavailable
+      const lat = geo.latitude || '28.6139';
+      const lng = geo.longitude || '77.2090';
+      const city = geo.city || 'New Delhi';
+      const country = geo.country || 'IN';
+
+      const url = request.nextUrl.clone();
+      url.searchParams.set('lat', lat);
+      url.searchParams.set('lng', lng);
+      url.searchParams.set('city', city);
+      url.searchParams.set('country', country);
+      url.searchParams.set('geo_source', geo.latitude ? 'edge' : 'fallback');
+
+      return NextResponse.rewrite(url);
+    }
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ['/map'],
+};

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -13,7 +13,7 @@ export function middleware(request: NextRequest) {
   if (pathname === '/map') {
     // If the coordinates are already explicitly specified in the query parameters, skip rewrite
     if (!searchParams.has('lat') || !searchParams.has('lng')) {
-      const geo = request.geo || {};
+      const geo = (request as any).geo || {};
       
       // Default to New Delhi, India coordinates during local dev or if geo is unavailable
       const lat = geo.latitude || '28.6139';


### PR DESCRIPTION
Closes #35. Implements Edge Middleware geolocation rewrites, dynamizes LeafletMap map centering with dynamic fly-to, and configures CDN caching headers on the map API endpoints.